### PR TITLE
Avoid erroring if input tree is null/undefined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-test-helper": "^1.1.0",
     "co": "^4.6.0",
     "qunit-eslint": "^1.0.0",
-    "qunitjs": "^2.3.2"
+    "qunitjs": "^2.4.0"
   },
   "dependencies": {
     "broccoli-plugin": "^1.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,11 @@ const minimatch = require("minimatch");
 module.exports = class BroccoliDebug extends Plugin {
   static buildDebugCallback(baseLabel) {
     return (input, labelOrOptions) => {
+      // return input value if falsey
+      if (!input) {
+        return input;
+      }
+
       let options = processOptions(labelOrOptions);
       options.label = `${baseLabel}:${options.label}`;
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -86,6 +86,22 @@ describe('BroccoliDebug', function(hooks) {
       assert.deepEqual(debug.read(), { 'foo-bar:herp': fixture }, 'debug tree output matches input');
     }));
 
+    it('does not error when provided a null tree when the BROCCOLI_DEBUG flag matches the label', function(assert) {
+      process.env.BROCCOLI_DEBUG = 'foo-bar:herp';
+
+      let debugTree = BroccoliDebug.buildDebugCallback('foo-bar');
+      let subject = debugTree(null, 'herp');
+
+      assert.equal(subject, null, 'passes `null` forward');
+    });
+
+    it('does not error when provided a null tree when the BROCCOLI_DEBUG flag does not matche', function(assert) {
+      let debugTree = BroccoliDebug.buildDebugCallback('foo-bar');
+      let subject = debugTree(null, 'herp');
+
+      assert.equal(subject, null, 'passes `null` forward');
+    });
+
     it('returns a BroccoliDebug tree when `force: true` option is passed', co.wrap(function* (assert) {
       input.write(fixture);
       let inputPath = input.path();

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,7 +722,7 @@ finalhandler@1.0.1:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
-findup-sync@^0.4.2, findup-sync@^0.4.3:
+findup-sync@0.4.3, findup-sync@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   dependencies:
@@ -1539,15 +1539,16 @@ qunit-eslint@^1.0.0:
     eslint "^3.19.0"
     walk-sync "^0.3.1"
 
-qunitjs@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.3.2.tgz#938ce24250aa3717b90b47598f1429b10343d85a"
+qunitjs@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.0.tgz#58f3a81e846687f2e7f637c5bedc9c267f887261"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"
     exists-stat "1.0.0"
-    findup-sync "^0.4.3"
+    findup-sync "0.4.3"
     js-reporters "1.2.0"
+    resolve "1.3.2"
     walk-sync "0.3.1"
 
 randomatic@^1.1.3:
@@ -1664,6 +1665,12 @@ resolve-dir@^0.1.0:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@^1.1.6:
   version "1.3.3"


### PR DESCRIPTION
Prior to this change, `null`/`undefined` was returned if the debug flag was not set, but if the debug flag matched we would error.

It is absolutely normal for build pipelines to speculatively deal with `null` / `undefined` input trees, and as such we should guarantee that we will not error with or without a match.