### PR TITLE
Avoid extra Broccoli node creation when not debugging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "src/"
   ],
   "devDependencies": {
+    "broccoli-source": "^1.1.0",
     "broccoli-test-helper": "^1.1.0",
     "co": "^4.6.0",
     "qunit-eslint": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,16 @@ module.exports = class BroccoliDebug extends Plugin {
   constructor(node, labelOrOptions) {
     let options = processOptions(labelOrOptions);
 
+    // this is used to avoid creating extraneous broccoli nodes when they are
+    // not going to be used for debugging purposes (e.g. `BROCCOLI_DEBUG=*`
+    // isn't present or doesn't apply to the current label)
+    //
+    // note: classes can only return an object or undefined from their
+    // constructor, hence the guard for typeof object
+    if (typeof node === 'object' && !options.force && !match(options.label)) {
+      return node;
+    }
+
     super([node], {
       name: 'BroccoliDebug',
       annotation: `DEBUG: ${options.label}`,


### PR DESCRIPTION
This effectively closes the gap between the `buildDebugCallback` and `new BroccoliDebug()` worlds. The result (after this change) is that `new BroccoliDebug()` introduces no additional overhead to the build when the label doesn't match the current `BROCCOLI_DEBUG` flag value.