### PR TITLE
Skip node creation for string input when not debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "src/"
   ],
   "devDependencies": {
-    "broccoli-source": "^1.1.0",
     "broccoli-test-helper": "^1.1.0",
     "co": "^4.6.0",
     "qunit-eslint": "^1.0.0",
@@ -31,6 +30,7 @@
   },
   "dependencies": {
     "broccoli-plugin": "^1.2.1",
+    "broccoli-source": "^1.1.0",
     "fs-tree-diff": "^0.5.2",
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.7",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const Plugin = require('broccoli-plugin');
 const TreeSync = require('tree-sync');
 const match = require('./match');
 const buildDebugOutputPath = require('./util').buildDebugOutputPath;
+const WatchedDir = require('broccoli-source').WatchedDir;
 
 module.exports = class BroccoliDebug extends Plugin {
   static buildDebugCallback(baseLabel) {
@@ -35,8 +36,8 @@ module.exports = class BroccoliDebug extends Plugin {
     //
     // note: classes can only return an object or undefined from their
     // constructor, hence the guard for typeof object
-    if (typeof node === 'object' && !options.force && !match(options.label)) {
-      return node;
+    if (!options.force && !match(options.label)) {
+      return typeof node === 'object' ? node : new WatchedDir(node);
     }
 
     super([node], {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,7 +3,9 @@ const BroccoliTestHelper = require('broccoli-test-helper');
 const buildOutput = BroccoliTestHelper.buildOutput;
 const createTempDir = BroccoliTestHelper.createTempDir;
 const co = require('co');
-const UnwatchedDir = require('broccoli-source').UnwatchedDir;
+const broccoliSource = require('broccoli-source');
+const UnwatchedDir = broccoliSource.UnwatchedDir;
+const WatchedDir = broccoliSource.WatchedDir;
 
 const BroccoliDebug = require('../src');
 const match = require('../src/match');
@@ -153,6 +155,20 @@ describe('BroccoliDebug', function(hooks) {
     let subject = new BroccoliDebug(inputTree, 'foo-bar');
 
     assert.equal(subject, inputTree, 'is equal to the input because the label does not match the BROCCOLI_DEBUG flag');
+
+    let output = yield buildOutput(subject);
+
+    assert.deepEqual(output.read(), fixture, 'final output matches input');
+    assert.deepEqual(debug.read(), { }, 'debug tree output is empty');
+  }));
+
+  it('returns the string input as a tree if debug flag does not match label', co.wrap(function* (assert) {
+    input.write(fixture);
+
+    let inputTree = input.path();
+    let subject = new BroccoliDebug(inputTree, 'foo-bar');
+
+    assert.ok(subject instanceof WatchedDir, 'returns watched source because the label does not match the BROCCOLI_DEBUG flag');
 
     let output = yield buildOutput(subject);
 


### PR DESCRIPTION
Extends changes in #15 to strings as inputNode.

As suggested here: https://github.com/broccolijs/broccoli-debug/pull/15#discussion_r222984702

Need that shirt, you know! 😝